### PR TITLE
Fixes: Auth + Release [semver:patch]

### DIFF
--- a/src/jobs/release.yml
+++ b/src/jobs/release.yml
@@ -45,6 +45,7 @@ steps:
   - setup:
       version: <<parameters.version>>
       token: <<parameters.token>>
+  - clone
   - run:
       name: "Creating a <<#parameters.draft>><<parameters.draft>> <</parameters.draft>>GitHub Release"
       environment:

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -11,5 +11,8 @@ fi
 if [ -n "$PARAM_GH_TITLE" ]; then
 	set -- "$@" --title "$PARAM_GH_TITLE"
 fi
+if [ -n "$PARAM_GH_FILES" ]; then
+	set -- "$@" " $PARAM_GH_FILES"
+fi
 
-gh release create "$PARAM_GH_TAG" "$@" "$PARAM_GH_FILES"
+gh release create "$PARAM_GH_TAG" "$@"

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -5,6 +5,7 @@ if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 # Get auth token
 export GITHUB_TOKEN=${!PARAM_GH_TOKEN}
 [ -z "$GITHUB_TOKEN" ] && echo "A GitHub token must be supplied. Check the \"token\" parameter." && exit 1
+echo "export GITHUB_TOKEN=\"${GITHUB_TOKEN}\"" >> "$BASH_ENV"
 # Define current platform
 if uname -a | grep "Darwin"; then
 	export SYS_ENV_PLATFORM=macos

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -3,8 +3,8 @@
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 # Get auth token
-PARAM_GH_TOKEN=${!PARAM_GH_TOKEN}
-[ -z "$PARAM_GH_TOKEN" ] && echo "A GitHub token must be supplied. Check the \"token\" parameter." && exit 1
+GH_TOKEN=${!PARAM_GH_TOKEN}
+[ -z "$GH_TOKEN" ] && echo "A GitHub token must be supplied. Check the \"token\" parameter." && exit 1
 # Define current platform
 if uname -a | grep "Darwin"; then
 	export SYS_ENV_PLATFORM=macos
@@ -54,7 +54,7 @@ fi
 # Authenticate
 echo
 echo "Authenticating GH CLI"
-gh auth login --with-token <<< "$PARAM_GH_TOKEN"
+gh auth login
 gh auth status
 
 # Configure

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -3,7 +3,7 @@
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 # Get auth token
-GITHUB_TOKEN=${!PARAM_GH_TOKEN}
+export GITHUB_TOKEN=${!PARAM_GH_TOKEN}
 [ -z "$GITHUB_TOKEN" ] && echo "A GitHub token must be supplied. Check the \"token\" parameter." && exit 1
 # Define current platform
 if uname -a | grep "Darwin"; then
@@ -54,7 +54,8 @@ fi
 # Authenticate
 echo
 echo "Authenticating GH CLI"
-git config --global 'credential.https://github.com' '!gh auth git-credential'
+git config --global credential.https://github.com.helper ''
+git config --global --add credential.https://github.com.helper "\!$(which gh) auth git-credential"
 gh auth status
 
 # Configure

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -3,8 +3,8 @@
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 # Get auth token
-GH_TOKEN=${!PARAM_GH_TOKEN}
-[ -z "$GH_TOKEN" ] && echo "A GitHub token must be supplied. Check the \"token\" parameter." && exit 1
+GITHUB_TOKEN=${!PARAM_GH_TOKEN}
+[ -z "$GITHUB_TOKEN" ] && echo "A GitHub token must be supplied. Check the \"token\" parameter." && exit 1
 # Define current platform
 if uname -a | grep "Darwin"; then
 	export SYS_ENV_PLATFORM=macos
@@ -54,7 +54,7 @@ fi
 # Authenticate
 echo
 echo "Authenticating GH CLI"
-gh auth login
+git config --global 'credential.https://github.com' '!gh auth git-credential'
 gh auth status
 
 # Configure


### PR DESCRIPTION
# Fixes

**Authentication:**
  -  Auth now expects your environment variables to be `GITHUB_TOKEN` or it will set what is provided to this value.
  - This fixes the issue that if `GITHUB_TOKEN` is already set, it takes precedence over what is provided manually.
  - All API requests will now utilize token-based auth.
 
**Release Job:**
  - Tested with a personal project and fixed.
  - Now clones code
  - Files parameter is optional
  - Example: https://github.com/KyleTryon/CircleCI-Metadata-Build/releases/tag/1.0.0