### PR TITLE
[semver:patch] Fix typo and align GitHub case

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 description: |
-  Manage your GitHub projects in your CI pipeline with the Github CLI orb integration.
+  Manage your GitHub projects in your CI pipeline with the GitHub CLI orb integration.
 
 display:
   home_url: "https://cli.github.com/manual/"

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -1,4 +1,4 @@
-description: Install and authenticate with the gh cli. This command should be ran before invoking the gh cli.
+description: Install and authenticate with the gh cli. This command should be run before invoking the gh cli.
 parameters:
     version:
         type: string

--- a/src/examples/install.yml
+++ b/src/examples/install.yml
@@ -1,5 +1,5 @@
 description: >
-  Simply install the Github CLI for manual usage.
+  Simply install the GitHub CLI for manual usage.
   The `setup` command is used to install and authenticate the GitHub CLI.
   Once the setup is complete, you can utilize the CLI manually, or use any of the other provided orb commands, such as `clone`.
 usage:

--- a/src/jobs/release.yml
+++ b/src/jobs/release.yml
@@ -24,7 +24,7 @@ parameters:
     default: false
     description: Mark the release as a prerelease.
   files:
-    description: "To include a subset of your repository's files in the release, enter the filt glob here. (e.g. ./dist/*.tgz) "
+    description: "To include a subset of your repository's files in the release, enter the file glob here. (e.g. ./dist/*.tgz) "
     default: ""
     type: string
   title:


### PR DESCRIPTION
Fixes a minor typo and aligns the vendor case of GitHub in a few places.