### PR TITLE
[semver:minor] Enable use with GitHub Enterprise

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -10,10 +10,16 @@ parameters:
         description: |
           Enter the name of the environment variable containing the GitHub Personal Access token to be used for authentication.
           It is recommended for CI processes that you create a "machine" user on GitHub.com with the needed permissions, rather than using your own.
+    hostname:
+        type: string
+        default: ""
+        description: |
+          The hostname of the GitHub instance to authenticate with. Used to login to Enterprise GitHub instance.
 steps:
   - run:
       environment:
           PARAM_GH_CLI_VERSION: <<parameters.version>>
           PARAM_GH_TOKEN: <<parameters.token>>
+          PARAM_GH_HOSTNAME: <<parameters.hostname>>
       name: Install GH CLI v<<parameters.version>>
       command: <<include(scripts/setup.sh)>>

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -9,7 +9,7 @@ echo "export GITHUB_TOKEN=\"${GITHUB_TOKEN}\"" >> "$BASH_ENV"
 # Get hostname
 export GITHUB_HOSTNAME=${!PARAM_GH_HOSTNAME}
 [ -z "$GITHUB_HOSTNAME" ] && echo "A GitHub token must be supplied. Check the \"token\" parameter." && exit 1
-echo "export GITHUB_TOKEN=\"${GITHUB_HOSTNAME}\"" >> "$BASH_ENV"
+echo "export GITHUB_HOSTNAME=\"${GITHUB_HOSTNAME}\"" >> "$BASH_ENV"
 # Define current platform
 if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "x86_64" ]]; then
 	export SYS_ENV_PLATFORM=macos


### PR DESCRIPTION
## Fixes Issue #9 

Enables use with Github Enterprise by accepting a hostname parameter. 

## Changes
-  `src/commands/setup.yml` Added parameter `hostname`. I'm not exactly sure what the default should be.
- `src/scripts/setup.sh` If `$GITHUB_HOSTNAME` is not empty use `gh auth login` with `$GITHUB_HOSTNAME` and `$GITHUB_TOKEN`.