### PR TITLE
[semver:patch] #12 Base is chosen implicitely

### DIFF
--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -14,5 +14,6 @@ fi
 if [ -n "$PARAM_GH_FILES" ]; then
 	set -- "$@" " $PARAM_GH_FILES"
 fi
+set -- "$@" --repo "$(git config --get remote.origin.url)"
 
 gh release create "$PARAM_GH_TAG" "$@"


### PR DESCRIPTION
This fix uses the hidden --release flag of the github cli tool to
create a release on the repository on which the pipeline is running
and not the one that it was forked from. The github cli tool asks
in interactive mode where to create the release but defaults to
the upstream which can lead to an unwanted official release during
testing as it happened to me.

With this fix this tool will default to origin which I assume is the only
sensible approach in a pipeline because origin presumably is the
one that the pipeline is running on.

- https://github.com/cli/cli/issues/4688
- Closes #12