### PR TITLE
[semver:minor] Fix for GitHub Enterprise support

### DIFF
--- a/src/examples/create_release.yml
+++ b/src/examples/create_release.yml
@@ -1,7 +1,7 @@
 description: >
   Use the GitHub CLI to issue a new release as a part of your CircleCI pipeline.
   In this example, on every commit (merge) to the "main" branch, we will use the config to specify the desired tag and issue a release.
-  Add a Context containing your GITHUB_TOKEN or set a project-level environment variable.
+  Add a Context containing your GITHUB_TOKEN and GITHUB_HOSTNAME (optional) or set a project-level environment variable.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/create_release.yml
+++ b/src/examples/create_release.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    gh: circleci/github-cli@1.0
+    gh: circleci/github-cli@2.0
     node: circleci/node@4.3
   workflows:
     test-and-deploy:

--- a/src/examples/install.yml
+++ b/src/examples/install.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    gh: circleci/github-cli@1.0
+    gh: circleci/github-cli@2.0
   jobs:
     create-a-deployment:
       docker:

--- a/src/examples/setup.yml
+++ b/src/examples/setup.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    gh: circleci/github-cli@1.0
+    gh: circleci/github-cli@2.0
   jobs:
     create-a-pr:
       docker:

--- a/src/jobs/release.yml
+++ b/src/jobs/release.yml
@@ -46,14 +46,14 @@ parameters:
       Enter the name of the environment variable containing the GitHub Personal Access token to be used for authentication.
       It is recommended for CI processes that you create a "machine" user on GitHub.com with the needed permissions, rather than using your own.
 steps:
-  - setup:
+  - install:
       version: <<parameters.version>>
-      token: <<parameters.token>>
-      hostname: <<parameters.hostname>>
   - clone
   - run:
       name: "Creating a <<#parameters.draft>><<parameters.draft>> <</parameters.draft>>GitHub Release"
       environment:
+        PARAM_GH_TOKEN: <<parameters.token>>
+        PARAM_GH_HOSTNAME: <<parameters.hostname>>
         PARAM_GH_TAG: <<parameters.tag>>
         PARAM_GH_NOTES: <<parameters.notes-file>>
         PARAM_GH_DRAFT: <<parameters.draft>>

--- a/src/jobs/release.yml
+++ b/src/jobs/release.yml
@@ -38,7 +38,7 @@ parameters:
   hostname:
       type: string
       default: "github.com"
-      description: Specify the hostname of the GitHub instance to authenticate with.
+      description: Specify the hostname of the GitHub instance to authenticate with. Set this to connect to your GitHub Enterprise instance.
   token:
     type: env_var_name
     default: "GITHUB_TOKEN"

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+# Get auth token
+export GITHUB_TOKEN=${!PARAM_GH_TOKEN}
+[ -z "$GITHUB_TOKEN" ] && echo "A GitHub token must be supplied. Check the \"token\" parameter." && exit 1
+echo "export GITHUB_TOKEN=\"${GITHUB_TOKEN}\"" >> "$BASH_ENV"
+
+# Get hostname if set
+if [ "$PARAM_GH_HOSTNAME" == 1 ]; then
+	export GITHUB_HOSTNAME=${!PARAM_GH_HOSTNAME}
+	echo "export GITHUB_HOSTNAME=\"${PARAM_GH_HOSTNAME}\"" >> "$BASH_ENV"
+fi
+
 if [ "$PARAM_GH_DRAFT" == 1 ]; then
 	set -- "$@" --draft
 fi


### PR DESCRIPTION
Fixes https://github.com/CircleCI-Public/github-cli-orb/issues/21

### Changes:
- `GITHUB_TOKEN` and `GITHUB_HOSTNAME` are exported in the release script because they are needed to make GitHub Enterprise work. 
- In the steps for `release` I replaced `setup` with `install` because `setup` is causing the error in #21.
- `token` and `hostname` params are moved to the `run` step for release because they will be needed.
- Updated descriptions to mention` GITHUB_HOSTNAME` and it's use.
- Updated the orb version numbers in  examples.

I'm not 100% sure this is the correct approach. If user were relying on `release` to  call `setup` this would break for them. I suppose an alternative would be to make an `enterprise_release` job and make it work only for enterprise. 

**Related Issue** https://github.com/CircleCI-Public/github-cli-orb/issues/9