### PR TITLE
feat: fetch RSA key at run time

### DIFF
--- a/src/commands/clone.yml
+++ b/src/commands/clone.yml
@@ -7,6 +7,10 @@ parameters:
     type: string
     default: "$CIRCLE_REPOSITORY_URL"
     description: Enter either the name of the repository or the full repository URL. Will default to the current project.
+  hostname:
+    type: string
+    default: "github.com"
+    description: Specify the hostname of the GitHub instance to authenticate with.
   dir:
     type: string
     default: "."
@@ -17,4 +21,5 @@ steps:
       environment:
         PARAM_GH_REPO: <<parameters.repo>>
         PARAM_GH_DIR: <<parameters.dir>>
+        PARAM_GH_HOSTNAME: <<parameters.hostname>>
       command: <<include(scripts/clone.sh)>>

--- a/src/scripts/clone.sh
+++ b/src/scripts/clone.sh
@@ -1,5 +1,7 @@
 # Ensure known hosts are entered. Required for Docker.
 mkdir -p ~/.ssh
-echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >>~/.ssh/known_hosts
+
+ssh-keyscan -t rsa "$PARAM_GH_HOSTNAME" >> ~/.ssh/known_hosts
+
 PARAM_GITHUB_REPO_EXPANDED="$(eval echo "$PARAM_GH_REPO")"
 gh repo clone "$PARAM_GITHUB_REPO_EXPANDED" "$PARAM_GH_DIR"


### PR DESCRIPTION
Aims to resolve #25 

The clone command can now support a custom hostname, used for both the SSH knownhosts as well as the API for fetching the RSA key.

I am unable to test test this on enterprise but do believe this should work, and is backwards compatible, so if there is a change needed for enterprise, it should be minor and non-breaking.