### PR TITLE
feat: support arm macos

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -5,6 +5,8 @@ if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 # Define current platform
 if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "x86_64" ]]; then
 	export SYS_ENV_PLATFORM=macos
+elif [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
+	export SYS_ENV_PLATFORM=macos_arm
 elif [[ "$(uname -s)" == "Linux" && "$(uname -m)" == "x86_64" ]]; then
 	export SYS_ENV_PLATFORM=linux_x86
 elif [[ "$(uname -s)" == "Linux" && "$(uname -m)" == "aarch64" ]]; then
@@ -34,6 +36,11 @@ if ! command -v gh >/dev/null 2>&1; then
 		$SUDO tar -xf ./gh-cli.tar.gz -C /usr/local/ --strip-components=1
 		rm gh-cli.tar.gz
 		;;
+	macos_arm)
+		curl -sSL "https://github.com/cli/cli/releases/download/v${PARAM_GH_CLI_VERSION}/gh_${PARAM_GH_CLI_VERSION}_macOS_arm64.tar.gz" -o "gh-cli.tar.gz"
+		$SUDO tar -xf ./gh-cli.tar.gz -C /usr/local/ --strip-components=1
+		rm gh-cli.tar.gz
+		;;	
 	*)
 		echo "This orb does not currently support your platform. If you believe it should, please consider opening an issue on the GitHub repository:"
 		echo "https://github.com/CircleCI-Public/github-cli-orb"


### PR DESCRIPTION
I think macos arm should be supported, because circleCI published m1 mac version executor.

related issue: https://github.com/CircleCI-Public/github-cli-orb/issues/42


```
# example of m1 mac's of mine uname -a

Darwin bh.local 22.6.0 Darwin Kernel Version 22.6.0: Wed Jul  5 22:22:52 PDT 2023; root:xnu-8796.141.3~6/RELEASE_ARM64_T8103 arm64
```