### PR TITLE
feat: add `when` parameter to all commands

### DIFF
--- a/src/commands/clone.yml
+++ b/src/commands/clone.yml
@@ -15,6 +15,10 @@ parameters:
     type: string
     default: "."
     description: Select the path to clone into. By default the current path will be selected, which is dictated by the job's "working_directory".
+  when:
+    type: string
+    default: "on_success"
+    description: Specify when to run this command. Options are "on_success", "always" or "on_fail".
 steps:
   - run:
       name: Cloning repository
@@ -23,3 +27,4 @@ steps:
         PARAM_GH_DIR: <<parameters.dir>>
         PARAM_GH_HOSTNAME: <<parameters.hostname>>
       command: <<include(scripts/clone.sh)>>
+      when: <<parameters.when>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -4,9 +4,14 @@ parameters:
     type: string
     default: "2.40.1"
     description: Specify the full semver versioned tag to use.
+  when:
+    type: string
+    default: "on_success"
+    description: Specify when to run this command. Options are "on_success", "always" or "on_fail".
 steps:
   - run:
       environment:
         PARAM_GH_CLI_VERSION: <<parameters.version>>
       name: Install GH CLI v<<parameters.version>>
       command: <<include(scripts/install.sh)>>
+      when: <<parameters.when>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -14,12 +14,18 @@ parameters:
     description: |
       Enter the name of the environment variable containing the GitHub Personal Access token to be used for authentication.
       It is recommended for CI processes that you create a "machine" user on GitHub.com with the needed permissions, rather than using your own.
+  when:
+    type: string
+    default: "on_success"
+    description: Specify when to run this command. Options are "on_success", "always" or "on_fail".
 steps:
   - install:
       version: <<parameters.version>>
+      when: <<parameters.when>>
   - run:
       environment:
         PARAM_GH_TOKEN: <<parameters.token>>
         PARAM_GH_HOSTNAME: <<parameters.hostname>>
       name: Configure GH CLI v<<parameters.version>>
       command: <<include(scripts/configure.sh)>>
+      when: <<parameters.when>>


### PR DESCRIPTION
In order to use CircleCI's common `when` command parameter in orbs, orb commands must have their own `when` parameter.

Here I'm adding `when` to each command so that `on_success`, `on_fail` or `always` can be plumbed through when needed.

This is useful in circumstances where you may need to, say, install the Github CLI as part of the steps taken after a CI job failure.

> [!NOTE]
> No tests have been added because AFAIK there's no way in Circle to validate failure flows for orbs. I've checked their docs, forums and the tests of several major public orbs that have popular `fail` features, and have found nothing.

## Example
Let's say you're trying to comment on a PR when there's a build failure:
```yaml
commands:
  build-failure-pr-comment:
    steps:
      - gh/setup
      - run: gh pr comment ...
          when: on_fail

jobs:
  build:
    steps:
      - run:
          name: example of failure in a build
          command: exit 1
      - build-failure-pr-comment 
```

The above `build` job will not work as expected on failure because `gh/setup` will be skipped. The only way around this currently is to add a separate `gh/setup` step to the build job before you expect any failures, which is very awkward.

With this PR change, we can instead do this:
```yaml
commands:
  build-failure-pr-comment:
    steps:
      - gh/setup:
          when: on_fail
      - run: gh pr comment ...
          when: on_fail

jobs:
  build:
    steps:
      - run:
          name: example of failure in a build
          command: exit 1
      - build-failure-pr-comment 
```

The above will work because gh/setup will still run even if the job itself fails.