### PR TITLE
Install additional/required dependencies while installing `github-cli`

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -52,7 +52,7 @@ install_gh_cli() {
 
     echo "Installing the GitHub CLI..."
     if [ "$platform" == "linux_amd64" ]; then 
-        set -x; $sudo apt install ./"$file_path"; set +x
+        set -x; $sudo apt install --yes ./"$file_path"; set +x
     else
         set -x; $sudo tar -xf ./"$file_path" -C /usr/local/ --strip-components=1; set +x
     fi


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:

- Adding `--yes` flag in `install.sh` command to install all required/additional dependencies while installing github-cli
- I faced this issue while install github-cli in one of my job.

```
Downloading the GitHub CLI from "https://github.com/cli/cli/releases/download/v2.40.1/gh_2.40.1_linux_amd64.deb"...
Installing the GitHub CLI...
+ apt install ./gh-cli.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'gh' instead of './gh-cli.deb'
The following additional packages will be installed:
  git git-man less libcbor0 liberror-perl libfido2-1 openssh-client patch
Suggested packages:
  gettext-base git-daemon-run | git-daemon-sysvinit git-doc git-el git-email
  git-gui gitk gitweb git-cvs git-mediawiki git-svn keychain libpam-ssh
  monkeysphere ssh-askpass ed diffutils-doc
The following NEW packages will be installed:
  gh git git-man less libcbor0 liberror-perl libfido2-1 openssh-client patch
0 upgraded, 9 newly installed, 0 to remove and 25 not upgraded.
Need to get 8653 kB/20.0 MB of archives.
After this operation, 86.8 MB of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
+ set +x
Something went wrong installing the GH CLI. Please try again or open an issue.

Exited with code exit status 1
```

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

 **Closes Issues:**
-  https://github.com/CircleCI-Public/github-cli-orb/issues/51

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [x] Changelog has been updated.