### PR TITLE
fix: Allow unauthenticated packages to be installed

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -52,7 +52,7 @@ install_gh_cli() {
 
     echo "Installing the GitHub CLI..."
     if [ "$platform" == "linux_amd64" ]; then 
-        set -x; $sudo apt install ./"$file_path"; set +x
+        set -x; $sudo apt --allow-unauthenticated install ./"$file_path"; set +x
     else
         set -x; $sudo tar -xf ./"$file_path" -C /usr/local/ --strip-components=1; set +x
     fi


### PR DESCRIPTION
This is a proposed work around to the expired GPG issue with the GitHub CLI packages - https://github.com/cli/cli/issues/9569.

The better fix is to support new keys, but this works and should be relatively safe as we know and mostly trust the source of the deb. 

It's a big improvement on the orb being broken as it is today.

This is intended as a workaround/fix for the problem described [here](https://github.com/CircleCI-Public/github-cli-orb/issues/58) 