### PR TITLE
Allow version param to be latest

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -55,7 +55,7 @@ workflows:
           matrix:
             parameters:
               executor: ["docker-x86-debian", "apple-silicon-14", "apple-silicon-15", "linuxvm-arm-ubuntu-2004", "linuxvm-x86-ubuntu-2004", "linuxvm-arm-ubuntu-2204", "linuxvm-x86-ubuntu-2204", "linuxvm-arm-ubuntu-2404", "linuxvm-x86-ubuntu-2404"]
-              version: [2.27.0, 2.40.0] # 2.27.0 is the last version that uses ".tar.gz" instead of ".zip" for macOS
+              version: [2.27.0, 2.40.0, "latest"] # 2.27.0 is the last version that uses ".tar.gz" instead of ".zip" for macOS
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -2,8 +2,8 @@ description: Install the gh cli without authenticating or configuring. This comm
 parameters:
   version:
     type: string
-    default: "2.40.1"
-    description: Specify the full semver versioned tag to use.
+    default: "latest"
+    description: Specify the full semver versioned tag to use. Default to latest.
   when:
     type: string
     default: "on_success"

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -2,8 +2,8 @@ description: Install and authenticate with the gh cli. This command should be ru
 parameters:
   version:
     type: string
-    default: "2.40.1"
-    description: Specify the full semver versioned tag to use.
+    default: "latest"
+    description: Specify the full semver versioned tag to use. Default to latest.
   hostname:
     type: string
     default: "github.com"

--- a/src/jobs/release.yml
+++ b/src/jobs/release.yml
@@ -33,8 +33,8 @@ parameters:
     default: ""
   version:
     type: string
-    default: "2.3.0"
-    description: Specify the full semver versioned tag to use for the GitHub CLI installation.
+    default: "latest"
+    description: Specify the full semver versioned tag to use for the GitHub CLI installation. Default to latest.
   additional_args:
     type: string
     default: ""

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -31,6 +31,10 @@ detect_platform() {
 download_gh_cli() {
     local platform=$1
     local file_extension=$2
+    if [ "$PARAM_GH_CLI_VERSION" = "latest" ]; then
+        LATEST_TAG=$(curl url -s https://api.github.com/repos/cli/cli/releases/latest | jq -r '.tag_name')
+        PARAM_GH_CLI_VERSION="${LATEST_TAG#v}"
+    fi
     local download_url="https://github.com/cli/cli/releases/download/v${PARAM_GH_CLI_VERSION}/gh_${PARAM_GH_CLI_VERSION}_${platform}.${file_extension}"
     echo "Downloading the GitHub CLI from \"$download_url\"..."
 


### PR DESCRIPTION
resolves #53 

This update allows to pass `latest` as the version to the install command and the ones using it. The new default will be latest now. The behavior for specific versions is not changed.

It is updating the description to make it clear, and adding a new test to the matrix to test this version.