### PR TITLE
Improve performance of pr-merge job

### DIFF
--- a/src/jobs/pr-merge.yml
+++ b/src/jobs/pr-merge.yml
@@ -22,6 +22,10 @@ parameters:
     description: >
       Specify the hostname of the GitHub instance to authenticate with.
       Set this to connect to your GitHub Enterprise instance.
+  repo:
+    type: string
+    default: "$CIRCLE_REPOSITORY_URL"
+    description: Enter either the name of the repository or the full repository URL. Will default to the current project.
   token:
     type: env_var_name
     default: "GITHUB_TOKEN"
@@ -36,12 +40,12 @@ parameters:
 steps:
   - install:
       version: <<parameters.version>>
-  - clone
   - run:
       name: "Merging PR to target branch"
       environment:
         ORB_EVAL_ADDITIONAL_ARGS: <<parameters.additional_args>>
         ORB_EVAL_BRANCH: <<parameters.branch>>
         ORB_EVAL_HOSTNAME: <<parameters.hostname>>
+        ORB_EVAL_REPO: <<parameters.repo>>
         ORB_ENV_TOKEN: <<parameters.token>>
       command: <<include(scripts/pr-merge.sh)>>

--- a/src/scripts/pr-merge.sh
+++ b/src/scripts/pr-merge.sh
@@ -11,10 +11,11 @@ token="${!ORB_ENV_TOKEN}"
 }
 printf '%s\n' "export GITHUB_TOKEN=$token" >>"$BASH_ENV"
 [ -n "$hostname" ] && printf '%s\n' "export GITHUB_HOSTNAME=$hostname" >>"$BASH_ENV"
+[ -n "$repo" ] && repo="-R $repo"
 
 set -x
 # shellcheck disable=SC2086
 gh pr merge \
-  $branch --repo "$repo" \
+  $branch $repo \
   $additional_args
 set +x

--- a/src/scripts/pr-merge.sh
+++ b/src/scripts/pr-merge.sh
@@ -2,6 +2,7 @@
 branch="$(eval printf '%s' "$ORB_EVAL_BRANCH")"
 additional_args="$(eval printf '%s\\n' "$ORB_EVAL_ADDITIONAL_ARGS")"
 hostname="$(eval printf '%s' "$ORB_EVAL_HOSTNAME")"
+repo="$(eval printf '%s' "$ORB_EVAL_REPO")"
 token="${!ORB_ENV_TOKEN}"
 
 [ -z "$token" ] && {
@@ -14,6 +15,6 @@ printf '%s\n' "export GITHUB_TOKEN=$token" >>"$BASH_ENV"
 set -x
 # shellcheck disable=SC2086
 gh pr merge \
-  $branch --repo "$(git config --get remote.origin.url)" \
+  $branch --repo "$repo" \
   $additional_args
 set +x


### PR DESCRIPTION
## Description

Remove the `clone` step from the `pr-merge` job.
Add `repo` parameter instead of the `clone` step. 

It is not efficient to perform a `clone` for a PR merge.
For example, running this operation on a very large repository can take several minutes.
I believe there is no need to clone full repository if you pass the repository name or URL as an argument to the `gh` command using the `--repo` option.
