### PR TITLE
fix: the branch parameter of pr-merge must be supplied.

### DIFF
--- a/src/jobs/pr-merge.yml
+++ b/src/jobs/pr-merge.yml
@@ -10,7 +10,7 @@ resource_class: small
 parameters:
   branch:
     type: string
-    default: ""
+    default: "$CIRCLE_BRANCH"
     description: "Enter PR number, branch or URL to merge. Without an argument, the pull request that belongs to the current branch is selected"
   additional_args:
     type: string

--- a/src/scripts/pr-merge.sh
+++ b/src/scripts/pr-merge.sh
@@ -9,6 +9,10 @@ token="${!ORB_ENV_TOKEN}"
   printf >&2 '%s\n' "A GitHub token must be supplied" "Check the \"token\" parameter."
   exit 1
 }
+[ -z "$branch" ] && {
+  printf >&2 '%s\n' "A target branch must be supplied" "Check the \"branch\" parameter."
+  exit 1
+}
 printf '%s\n' "export GITHUB_TOKEN=$token" >>"$BASH_ENV"
 [ -n "$hostname" ] && printf '%s\n' "export GITHUB_HOSTNAME=$hostname" >>"$BASH_ENV"
 [ -n "$repo" ] && repo="-R $repo"


### PR DESCRIPTION
Related to #65

My apologies for the insufficient validation of parameters on previous Pull Request.  
The branch parameter must be specified, but using $CIRCLE_BRANCH as the default should be enough for now, I believe.