### PR TITLE
fix: additional-args does not accept quoted string

### DIFF
--- a/src/scripts/pr-merge.sh
+++ b/src/scripts/pr-merge.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 branch="$(eval printf '%s' "$ORB_EVAL_BRANCH")"
-additional_args="$(eval printf '%s\\n' "$ORB_EVAL_ADDITIONAL_ARGS")"
+readarray -t additional_args < <(eval "set -- $ORB_EVAL_ADDITIONAL_ARGS; printf '%s\n' \"\$@\"")
 hostname="$(eval printf '%s' "$ORB_EVAL_HOSTNAME")"
 repo="$(eval printf '%s' "$ORB_EVAL_REPO")"
 token="${!ORB_ENV_TOKEN}"
@@ -17,5 +17,5 @@ set -x
 # shellcheck disable=SC2086
 gh pr merge \
   $branch $repo \
-  $additional_args
+  "${additional_args[@]}"
 set +x


### PR DESCRIPTION
## Description

The `additional-args` parameter does not work properly when it contains a string like `"--merge -d -b 'commit message body'"`.
In the script, the command `"$(eval printf '%s\\n' "$ORB_EVAL_ADDITIONAL_ARGS")"` removes the quotes around `'commit message body'`.
As a result, the argument string becomes `--merge -d -b commit message body`, which causes an invalid argument error such as:
```console
accepts at most 1 arg(s), received 3
```

## Resolution 
Do not pass arguments as a single string.
Instead, use an array to preserve the structure of arguments.