### PR TITLE
Allow to pass max_retires during gh/setup

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -18,10 +18,16 @@ parameters:
     type: string
     default: "on_success"
     description: Specify when to run this command. Options are "on_success", "always" or "on_fail".
+  max_retries:
+    type: integer
+    default: 5
+    description: Max of retries to do when the request to github releases fails.
+
 steps:
   - install:
       version: <<parameters.version>>
       when: <<parameters.when>>
+      max_retries: <<parameters.max_retries>>
   - run:
       environment:
         PARAM_GH_TOKEN: <<parameters.token>>


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

Allow to pass `max_retries` during `gh/setup` commend.

## Motivation:

There is no options to pass `max_retries` when using `gh/setup`.

## Checklist:

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [ ] ~Changelog has been updated~. (where is `CHANGELOG.md`?)