### PR TITLE
feat: add GitHub App authentication alongside PAT

### DIFF
--- a/src/commands/mint-app-token.yml
+++ b/src/commands/mint-app-token.yml
@@ -1,0 +1,87 @@
+description: >
+  Mint a short-lived GitHub App installation access token and export it via
+  $BASH_ENV under the env var name given by `export_as` (default GITHUB_TOKEN).
+  The resulting token behaves identically to a PAT for `gh`, `git`, and the
+  GitHub REST/GraphQL APIs, but is scoped to the App's installation permissions
+  and expires within the hour.
+
+  Requires `jq`, `openssl`, and `curl`; the command will install them via
+  apt/apk/yum if missing.
+
+parameters:
+  app_id:
+    type: env_var_name
+    default: "GITHUB_APP_ID"
+    description: Env var containing the numeric GitHub App ID.
+  private_key:
+    type: env_var_name
+    default: "GITHUB_APP_PRIVATE_KEY"
+    description: >
+      Env var containing the App private key. Accepts either a raw PEM block
+      (literal "\n" sequences will be expanded to newlines) or a base64-encoded
+      PEM, which is how CircleCI contexts typically store multi-line secrets.
+  installation_id:
+    type: env_var_name
+    default: "GITHUB_APP_INSTALLATION_ID"
+    description: >
+      Env var holding a pinned installation id. If set and non-empty, it is
+      used directly. Otherwise the command discovers the installation using
+      `installation_owner` and `installation_repo`.
+  installation_owner:
+    type: string
+    default: "$CIRCLE_PROJECT_USERNAME"
+    description: Owner (user or org) to look up the App installation under.
+  installation_repo:
+    type: string
+    default: "$CIRCLE_PROJECT_REPONAME"
+    description: >
+      Repository used to discover the installation via
+      `GET /repos/:owner/:repo/installation`. Leave empty to fall back to
+      `GET /orgs/:owner/installation` for an org-wide installation.
+  permissions:
+    type: string
+    default: ""
+    description: >
+      Optional JSON object passed as the `permissions` field of
+      `POST /app/installations/:id/access_tokens`, used to narrow the token
+      below the installation's configured permissions. Example:
+      '{"contents":"write","pull_requests":"write"}'
+  repositories:
+    type: string
+    default: ""
+    description: >
+      Optional JSON array of repo names (not full owner/name) to scope the
+      token to. Example: '["github-cli-orb","orb-tools"]'
+  hostname:
+    type: string
+    default: "github.com"
+    description: >
+      Specify the hostname of the GitHub instance. For GitHub Enterprise
+      Server, API calls are routed to `https://<hostname>/api/v3`.
+  export_as:
+    type: env_var_name
+    default: "GITHUB_TOKEN"
+    description: >
+      Name of the env var to export the minted token into via $BASH_ENV.
+      Default matches the env var `gh/setup` reads, so chaining this command
+      before `gh/setup` works without further wiring.
+  when:
+    type: string
+    default: "on_success"
+    description: Specify when to run this command. Options are "on_success", "always" or "on_fail".
+
+steps:
+  - run:
+      name: Mint GitHub App installation token
+      environment:
+        PARAM_APP_ID: <<parameters.app_id>>
+        PARAM_PRIVATE_KEY: <<parameters.private_key>>
+        PARAM_INSTALLATION_ID: <<parameters.installation_id>>
+        PARAM_INSTALLATION_OWNER: <<parameters.installation_owner>>
+        PARAM_INSTALLATION_REPO: <<parameters.installation_repo>>
+        PARAM_PERMISSIONS: <<parameters.permissions>>
+        PARAM_REPOSITORIES: <<parameters.repositories>>
+        PARAM_HOSTNAME: <<parameters.hostname>>
+        PARAM_EXPORT_AS: <<parameters.export_as>>
+      command: <<include(scripts/mint-app-token.sh)>>
+      when: <<parameters.when>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -14,6 +14,7 @@ parameters:
     description: |
       Enter the name of the environment variable containing the GitHub Personal Access token to be used for authentication.
       It is recommended for CI processes that you create a "machine" user on GitHub.com with the needed permissions, rather than using your own.
+      When `auth_method` is `app`, this env var is instead populated by `mint-app-token` with a short-lived installation token.
   when:
     type: string
     default: "on_success"
@@ -22,12 +23,65 @@ parameters:
     type: integer
     default: 5
     description: Max of retries to do when the request to github releases fails.
+  auth_method:
+    type: enum
+    enum: ["pat", "app"]
+    default: "pat"
+    description: >
+      How to authenticate. `pat` (default) reads the env var named by `token`.
+      `app` first mints a short-lived GitHub App installation access token (see
+      the `mint-app-token` command) into that same env var, then continues with
+      the normal configure step. The App params below are only consulted when
+      `auth_method: app`.
+  app_id:
+    type: env_var_name
+    default: "GITHUB_APP_ID"
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  private_key:
+    type: env_var_name
+    default: "GITHUB_APP_PRIVATE_KEY"
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  installation_id:
+    type: env_var_name
+    default: "GITHUB_APP_INSTALLATION_ID"
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  installation_owner:
+    type: string
+    default: "$CIRCLE_PROJECT_USERNAME"
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  installation_repo:
+    type: string
+    default: "$CIRCLE_PROJECT_REPONAME"
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  permissions:
+    type: string
+    default: ""
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  repositories:
+    type: string
+    default: ""
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
 
 steps:
   - install:
       version: <<parameters.version>>
       when: <<parameters.when>>
       max_retries: <<parameters.max_retries>>
+  - when:
+      condition:
+        equal: ["app", <<parameters.auth_method>>]
+      steps:
+        - mint-app-token:
+            app_id: <<parameters.app_id>>
+            private_key: <<parameters.private_key>>
+            installation_id: <<parameters.installation_id>>
+            installation_owner: <<parameters.installation_owner>>
+            installation_repo: <<parameters.installation_repo>>
+            permissions: <<parameters.permissions>>
+            repositories: <<parameters.repositories>>
+            hostname: <<parameters.hostname>>
+            export_as: <<parameters.token>>
+            when: <<parameters.when>>
   - run:
       environment:
         PARAM_GH_TOKEN: <<parameters.token>>

--- a/src/examples/app_auth.yml
+++ b/src/examples/app_auth.yml
@@ -1,0 +1,50 @@
+description: >
+  Authenticate the GitHub CLI as a GitHub App installation instead of using a
+  long-lived Personal Access Token. The context stores `GITHUB_APP_ID` and
+  `GITHUB_APP_PRIVATE_KEY` (a base64-encoded PEM is typical, since CircleCI
+  contexts render awkwardly for multi-line secrets). A short-lived
+  installation access token is minted per job and exported as `GITHUB_TOKEN`,
+  scoped to the permissions configured on the App and expiring within the
+  hour. Works transparently with `gh/release`, `gh/clone`, and any step that
+  reads `$GITHUB_TOKEN`.
+usage:
+  version: "2.1"
+  orbs:
+    gh: circleci/github-cli@x.y
+  workflows:
+    release:
+      jobs:
+        - gh/release:
+            context: [github-app]
+            auth_method: app
+            tag: $CIRCLE_TAG
+            title: $CIRCLE_TAG
+            notes-file: changelog.md
+            filters:
+              tags:
+                only: /^v.*/
+              branches:
+                ignore: /.*/
+    # For non-`gh` use (e.g. pushing tags, curling the REST API), call
+    # `mint-app-token` directly. The minted token is exported as GITHUB_TOKEN
+    # via $BASH_ENV and is available to every subsequent step in the job.
+    push-tag:
+      jobs:
+        - create-and-push-tag:
+            context: [github-app]
+  jobs:
+    create-and-push-tag:
+      docker:
+        - image: cimg/base:stable
+      steps:
+        - checkout
+        - gh/mint-app-token
+        - run:
+            name: Push signed tag as the GitHub App
+            command: |
+              git config user.email "ci@users.noreply.github.com"
+              git config user.name  "ci"
+              git tag -a "v1.2.3" -m "Release v1.2.3"
+              git remote set-url origin \
+                "https://x-access-token:${GITHUB_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+              git push origin "v1.2.3"

--- a/src/jobs/release.yml
+++ b/src/jobs/release.yml
@@ -61,11 +61,57 @@ parameters:
     type: boolean
     default: true
     description: Whether or not clone the repo. Defaults to true. Set to false if you already cloned the repo.
+  auth_method:
+    type: enum
+    enum: ["pat", "app"]
+    default: "pat"
+    description: >
+      How to authenticate. `pat` (default) uses the env var named by `token`.
+      `app` mints a short-lived GitHub App installation access token into that
+      env var before the `gh` CLI is configured. When using `app`, provide the
+      App context via `app_id` / `private_key` (and optionally the other
+      `installation_*` / scoping parameters below).
+  app_id:
+    type: env_var_name
+    default: "GITHUB_APP_ID"
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  private_key:
+    type: env_var_name
+    default: "GITHUB_APP_PRIVATE_KEY"
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  installation_id:
+    type: env_var_name
+    default: "GITHUB_APP_INSTALLATION_ID"
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  installation_owner:
+    type: string
+    default: "$CIRCLE_PROJECT_USERNAME"
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  installation_repo:
+    type: string
+    default: "$CIRCLE_PROJECT_REPONAME"
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  permissions:
+    type: string
+    default: ""
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
+  repositories:
+    type: string
+    default: ""
+    description: "Only used when auth_method is `app`. See `mint-app-token`."
 steps:
   - setup:
       version: <<parameters.version>>
       token: <<parameters.token>>
       hostname: <<parameters.hostname>>
+      auth_method: <<parameters.auth_method>>
+      app_id: <<parameters.app_id>>
+      private_key: <<parameters.private_key>>
+      installation_id: <<parameters.installation_id>>
+      installation_owner: <<parameters.installation_owner>>
+      installation_repo: <<parameters.installation_repo>>
+      permissions: <<parameters.permissions>>
+      repositories: <<parameters.repositories>>
   - when:
       condition: <<parameters.clone>>
       steps:

--- a/src/scripts/mint-app-token.sh
+++ b/src/scripts/mint-app-token.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# shellcheck disable=SC2016
+set -euo pipefail
+
+# Ensure required tools are available. These are commonly present on cimg/*
+# images but not guaranteed on bare machine executors or alpine-based images.
+need=()
+for bin in jq openssl curl; do
+    command -v "$bin" >/dev/null 2>&1 || need+=("$bin")
+done
+if [ "${#need[@]}" -gt 0 ]; then
+    if command -v apt-get >/dev/null 2>&1; then
+        SUDO=""
+        [ "$(id -u)" -ne 0 ] && SUDO="sudo"
+        $SUDO apt-get update -qq
+        $SUDO apt-get install -y -qq "${need[@]}" >/dev/null
+    elif command -v apk >/dev/null 2>&1; then
+        apk add --no-cache "${need[@]}" >/dev/null
+    elif command -v yum >/dev/null 2>&1; then
+        SUDO=""
+        [ "$(id -u)" -ne 0 ] && SUDO="sudo"
+        $SUDO yum install -y "${need[@]}" >/dev/null
+    else
+        echo "Missing required tools (${need[*]}) and no supported package manager (apt-get/apk/yum) was found." >&2
+        exit 1
+    fi
+fi
+
+APP_ID_VAL="${!PARAM_APP_ID:-}"
+PRIVATE_KEY_VAL="${!PARAM_PRIVATE_KEY:-}"
+INSTALL_ID_VAL="${!PARAM_INSTALLATION_ID:-}"
+
+if [ -z "$APP_ID_VAL" ]; then
+    echo "App ID env var '$PARAM_APP_ID' is empty. Set it on the job context." >&2
+    exit 1
+fi
+if [ -z "$PRIVATE_KEY_VAL" ]; then
+    echo "Private key env var '$PARAM_PRIVATE_KEY' is empty. Set it on the job context." >&2
+    exit 1
+fi
+
+OWNER="$(eval printf '%s' "$PARAM_INSTALLATION_OWNER")"
+REPO="$(eval printf '%s' "$PARAM_INSTALLATION_REPO")"
+
+if [ "$PARAM_HOSTNAME" = "github.com" ]; then
+    API="https://api.github.com"
+else
+    API="https://${PARAM_HOSTNAME}/api/v3"
+fi
+
+# Accept either a raw PEM (possibly with literal "\n") or a base64-encoded PEM.
+# CircleCI contexts render awkwardly for multi-line values, so base64 is a
+# common way teams store App private keys.
+PEM="$(mktemp)"
+chmod 600 "$PEM"
+trap 'rm -f "$PEM"' EXIT
+if printf '%s' "$PRIVATE_KEY_VAL" | grep -q "BEGIN"; then
+    printf '%s' "$PRIVATE_KEY_VAL" | sed 's/\\n/\n/g' > "$PEM"
+else
+    printf '%s' "$PRIVATE_KEY_VAL" | tr -d '[:space:]' | base64 -d > "$PEM"
+fi
+
+b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+now=$(date +%s)
+header="$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)"
+# iat -60s to tolerate clock skew; exp +9m is the max allowed by GitHub.
+payload="$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((now - 60))" "$((now + 540))" "$APP_ID_VAL" | b64url)"
+sig="$(printf '%s' "${header}.${payload}" | openssl dgst -sha256 -sign "$PEM" -binary | b64url)"
+JWT="${header}.${payload}.${sig}"
+
+# Intentionally no `set -x` anywhere in this script: the JWT and the minted
+# token are both sensitive and must never land in build logs.
+
+AUTH_HEADER="Authorization: Bearer $JWT"
+ACCEPT_HEADER="Accept: application/vnd.github+json"
+
+if [ -z "$INSTALL_ID_VAL" ]; then
+    if [ -n "$REPO" ]; then
+        INSTALL_ID_VAL="$(curl -sSf \
+            -H "$AUTH_HEADER" \
+            -H "$ACCEPT_HEADER" \
+            "$API/repos/$OWNER/$REPO/installation" | jq -r .id)"
+    else
+        INSTALL_ID_VAL="$(curl -sSf \
+            -H "$AUTH_HEADER" \
+            -H "$ACCEPT_HEADER" \
+            "$API/orgs/$OWNER/installation" | jq -r .id)"
+    fi
+fi
+
+if [ -z "$INSTALL_ID_VAL" ] || [ "$INSTALL_ID_VAL" = "null" ]; then
+    echo "Could not resolve a GitHub App installation id for owner=$OWNER repo=$REPO." >&2
+    echo "Either install the App on that target, or set the env var named by 'installation_id'." >&2
+    exit 1
+fi
+
+# Build the POST body. Only include "permissions" / "repositories" when the
+# caller provided them; sending empty values would 422 from the API.
+BODY="{}"
+if [ -n "$PARAM_PERMISSIONS" ] && [ -n "$PARAM_REPOSITORIES" ]; then
+    BODY="$(jq -cn \
+        --argjson perms "$PARAM_PERMISSIONS" \
+        --argjson repos "$PARAM_REPOSITORIES" \
+        '{permissions: $perms, repositories: $repos}')"
+elif [ -n "$PARAM_PERMISSIONS" ]; then
+    BODY="$(jq -cn --argjson perms "$PARAM_PERMISSIONS" '{permissions: $perms}')"
+elif [ -n "$PARAM_REPOSITORIES" ]; then
+    BODY="$(jq -cn --argjson repos "$PARAM_REPOSITORIES" '{repositories: $repos}')"
+fi
+
+TOKEN="$(curl -sSf -X POST \
+    -H "$AUTH_HEADER" \
+    -H "$ACCEPT_HEADER" \
+    -H "Content-Type: application/json" \
+    -d "$BODY" \
+    "$API/app/installations/$INSTALL_ID_VAL/access_tokens" | jq -r .token)"
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+    echo "Failed to mint installation access token." >&2
+    exit 1
+fi
+
+# Export the minted token into $BASH_ENV so subsequent steps can consume it.
+# Downstream `gh/setup` reads the env var named by its `token` parameter, so
+# setting `export_as` to that same name (default GITHUB_TOKEN) makes the App
+# path transparent to the rest of the orb.
+printf 'export %s=%s\n' "$PARAM_EXPORT_AS" "$TOKEN" >> "$BASH_ENV"
+
+echo "Minted GitHub App installation token (installation id=$INSTALL_ID_VAL) and exported as \$$PARAM_EXPORT_AS."


### PR DESCRIPTION
## Summary

Adds a first-class GitHub App auth path alongside the existing PAT flow. Fully additive and backward compatible.

- **New `gh/mint-app-token` command**: signs a JWT, calls `POST /app/installations/:id/access_tokens`, and exports the minted token via `$BASH_ENV` (as `GITHUB_TOKEN` by default). Usable standalone for `git push`, `curl api.github.com`, etc.
- **`gh/setup` gains `auth_method: app`**: when set, it chains `mint-app-token` before the existing configure step. The minted token is written into the same env var `setup` already reads, so `configure.sh` and downstream jobs work unchanged.
- **`gh/release` forwards the new params** so an App can be used end-to-end in the stock release job.
- **New example** at `src/examples/app_auth.yml`.

### Why

App installation tokens are strictly stronger than long-lived machine-user PATs: short-lived (~1h), scoped to the App's permissions/repositories, and further narrowable per-call via the `permissions` / `repositories` passthrough params. Today every team wanting this pastes ~50 lines of `openssl`/`jq`/`curl` into their config; this bakes it into the orb.

### Implementation notes

- Pure shell: RS256 JWT via `openssl dgst`, no Node/Python deps.
- Installs `jq`/`openssl`/`curl` via `apt`/`apk`/`yum` if missing (same pattern as `install.sh`).
- Accepts the private key as either a raw PEM (literal `\n` expanded) or a base64-encoded PEM.
- Supports github.com and GHES (`https://<hostname>/api/v3`).
- Installation resolution: pinned env var, then `/repos/:owner/:repo/installation`, then `/orgs/:owner/installation`.
- Never runs `set -x`; JWT, PEM, and minted token never hit the log.
- `configure.sh`, `install.sh`, `clone.sh`, `release.sh`, `upload.sh`, `pr-merge.sh` untouched.

### Backward compatibility

- `auth_method` defaults to `pat`; existing pipelines see no behavioral change.
- New param defaults: `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_INSTALLATION_ID`, `$CIRCLE_PROJECT_USERNAME`, `$CIRCLE_PROJECT_REPONAME`.
- `mint-app-token` is a new command, no collision surface.

## Test plan

Local:

- [x] `circleci orb pack src` succeeds
- [x] `circleci orb validate` passes on the packed orb
- [x] `shellcheck src/scripts/mint-app-token.sh` clean
- [x] `yamllint` clean on all new/changed files

CI:

- [ ] `orb-tools/lint`, `orb-tools/review`, `orb-tools/pack`, `shellcheck/check` pass
- [ ] Existing `integration-test-1` matrix passes unchanged (PAT path untouched)

### Possible follow-ups

- Integration test that mints a real token against a test App installed on this repo and exercises `gh api /repos/...`.
- Forward `auth_method` through `gh/upload` and `gh/pr-merge` (they bypass `setup`, so they need separate wiring).